### PR TITLE
Deprecated since jQuery 1.8.

### DIFF
--- a/jquery.autoheight.js
+++ b/jquery.autoheight.js
@@ -92,7 +92,7 @@
             });
         }
 
-        $(window).load(setup(this));
+        $(window).on('load', setup(this));
         resizeEvent(this);
 
         // chain jQuery functions


### PR DESCRIPTION
AutoHeight Javascript using jQuery event aliases like .load, .unload or .error which have been deprecated since jQuery 1.8.